### PR TITLE
feat:use context manager to open and close clipboard automatically

### DIFF
--- a/clipette/__init__.py
+++ b/clipette/__init__.py
@@ -26,6 +26,7 @@ import ctypes
 from os.path import join as path_join
 from sys import getfilesystemencoding
 import utils
+from contextlib import contextmanager
 
 
 class ClipetteWin32ClipboardError(Exception):
@@ -96,6 +97,19 @@ def close_clipboard() -> int:
     :rtype: int
     """
     return utils.user32.CloseClipboard()
+
+@contextmanager
+def clipboard():
+    """
+    Context manager to open and close clipboard automatically.
+
+    :return: if function fails, 1 otherwise.
+    :rtype: int
+    """
+    res = open_clipboard()
+    yield res
+    if res: close_clipboard()
+
 
 def empty_clipboard() -> int:
     """

--- a/example.py
+++ b/example.py
@@ -3,3 +3,8 @@ if clipette.open_clipboard():
     clipette.empty_cliboard()
     clipette.set_UNICODETEXT("<some text>")
     clipette.close_clipboard()
+
+# safe clipboard
+with clipette.clipboard():
+    clipette.empty_cliboard()
+    clipette.set_UNICODETEXT("<some text>")


### PR DESCRIPTION
maybe a easier way to use it
```python
import clipette

# old
if clipette.open_clipboard():
    clipette.empty_cliboard()
    clipette.set_UNICODETEXT("<some text>")
    clipette.close_clipboard()

# new
with clipette.clipboard():
    clipette.empty_cliboard()
    clipette.set_UNICODETEXT("<some text>")
```